### PR TITLE
Added configuration for closure compiler options (both global and per file)

### DIFF
--- a/ClosureCompilerGrailsPlugin.groovy
+++ b/ClosureCompilerGrailsPlugin.groovy
@@ -6,7 +6,7 @@ class ClosureCompilerGrailsPlugin {
     // the version or versions of Grails the plugin is designed for
     def grailsVersion = "1.3 > *"
     // the other plugins this plugin depends on
-    def dependsOn = [resources:'1.0 > *']
+    def dependsOn = [resources: '1.1.6 > *']
     // resources that are excluded from plugin packaging
     def pluginExcludes = [
         "grails-app/views/error.gsp"
@@ -46,7 +46,7 @@ N.B. It builds/depends on the Grails Resources Plugin.
     def doWithSpring = {
         if (application.config.closurecompiler.compilation_level) {
             //Backward compatibility
-            grails.resources.mappers.googleclosurecompiler.compilation_level = 'SIMPLE_OPTIMIZATIONS'
+            application.config.grails.resources.mappers.googleclosurecompiler.compilation_level = application.config.closurecompiler.compilation_level
         }
     }
 }

--- a/ClosureCompilerGrailsPlugin.groovy
+++ b/ClosureCompilerGrailsPlugin.groovy
@@ -44,8 +44,9 @@ N.B. It builds/depends on the Grails Resources Plugin.
     def scm = [ url: "https://github.com/oyvinmar/grails-closure-compiler" ]
 
     def doWithSpring = {
-        if (!application.config.closurecompiler.compilation_level) {
-            application.config.closurecompiler.compilation_level= 'SIMPLE_OPTIMIZATIONS'
+        if (application.config.closurecompiler.compilation_level) {
+            //Backward compatibility
+            grails.resources.mappers.googleclosurecompiler.compilation_level = 'SIMPLE_OPTIMIZATIONS'
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -28,8 +28,19 @@ The Google Closure compiler have three different compilation levels:
 
 These can be configured with the variable:
 
-    closurecompiler.compilation_level
+    grails.resources.mappers.googleclosurecompiler.compilation_level
 
 The default level is SIMPLE_OPTIMIZATIONS
-
 See the [Google Closure Compiler Docs] (https://developers.google.com/closure/compiler/docs/compilation_levels) for more information.
+
+You can also add custom compiler configuration by adding them to the configuration:
+
+    grails.resources.mappers.googleclosurecompiler.compilation_level = 'SIMPLE_OPTIMIZATIONS'
+    grails.resources.mappers.googleclosurecompiler.compilerOptions = [
+        languageIn: CompilerOptions.LanguageMode.ECMASCRIPT5
+    ]
+
+If you want specify compiler options for a single file, it can be done using the attrs map in the ApplicationResource file:
+
+    resource url: 'js/ember.js', attrs: [googlecompiler: [languageIn: CompilerOptions.LanguageMode.ECMASCRIPT5]]
+

--- a/grails-app/resourceMappers/org/grails/plugin/gccresources/GoogleClosureCompilerResourceMapper.groovy
+++ b/grails-app/resourceMappers/org/grails/plugin/gccresources/GoogleClosureCompilerResourceMapper.groovy
@@ -17,6 +17,10 @@ class GoogleClosureCompilerResourceMapper {
     static defaultIncludes = ['**/*.js']
 
     def map(resource, config) {
+        if (config.disable) {
+            return false
+        }
+
         if (resource instanceof JavaScriptBundleResourceMeta) {
             return false
         }
@@ -26,7 +30,18 @@ class GoogleClosureCompilerResourceMapper {
 
         CompilerOptions options = new CompilerOptions();
 
-        def compilation_level = grailsApplication.config.closurecompiler.compilation_level
+        config?.compilerOptions?.each { k, v ->
+            log.debug "Setting google closure compiler options: ${v} = ${k}"
+            options[k] = v
+        }
+
+        def resourceConfig = resource.tagAttributes?.size() ? resource.tagAttributes['googlecompiler'] : null
+        resourceConfig?.each { k, v ->
+            log.debug "Setting google closure compiler options: ${v} = ${k} on resource ${resource.id}"
+            options[k] = v
+        }
+
+        def compilation_level = config.compilation_level ?: 'SIMPLE_OPTIMIZATIONS'
         if (compilation_level == 'WHITESPACE_ONLY') {
             CompilationLevel.WHITESPACE_ONLY.setOptionsForCompilationLevel(options)
         } else if (compilation_level == 'ADVANCED_OPTIMIZATIONS') {

--- a/test/integration/org/grails/plugin/gccresources/MapperTests.groovy
+++ b/test/integration/org/grails/plugin/gccresources/MapperTests.groovy
@@ -12,8 +12,8 @@ class MapperTests extends GrailsUnitTestCase {
         def before = r.processedFile.size()
 
         GoogleClosureCompilerResourceMapper.newInstance().with {
-            grailsApplication = [config : new ConfigSlurper().parse("closurecompiler.compilation_level = 'SIMPLE_OPTIMIZATIONS'")]
-            map(r, new ConfigObject())
+            grailsApplication = [config : new ConfigSlurper().parse("grails.resources.mappers.googleclosurecompiler.compilation_level = 'SIMPLE_OPTIMIZATIONS'")]
+            map(r, grailsApplication.config.grails.resources.mappers.googleclosurecompiler)
         }
 
         assertTrue(r.processedFile.size() < before)
@@ -34,12 +34,12 @@ class MapperTests extends GrailsUnitTestCase {
         def resourceMeta = new ResourceMeta()
         def filePath = System.getProperty("user.dir") + '/web-app/js/test.js'
         resourceMeta.processedFile = new File(filePath + '.copy.js') << new File(filePath).text
-        def conf = "closurecompiler.compilation_level = '${level}'"
+        def conf = "grails.resources.mappers.googleclosurecompiler.compilation_level = '${level}'"
         def configObject = new ConfigSlurper().parse(conf)
 
         GoogleClosureCompilerResourceMapper.newInstance().with {
             grailsApplication = [config : configObject]
-            map(resourceMeta, new ConfigObject())
+            map(resourceMeta, grailsApplication.config.grails.resources.mappers.googleclosurecompiler)
         }
 
         def size = resourceMeta.processedFile.size()


### PR DESCRIPTION
This allows to add compiler options in the configuration. I also used default resource mapper config object to adhere other plugin standard.

Now it's possible to add custom compiler configuration by adding them to the configuration:

```
grails.resources.mappers.googleclosurecompiler.compilation_level = 'SIMPLE_OPTIMIZATIONS'
grails.resources.mappers.googleclosurecompiler.compilerOptions = [
    languageIn: CompilerOptions.LanguageMode.ECMASCRIPT5
]
```

If you want specify compiler options for a single file, it can be done using the attrs map in the ApplicationResource file:

```
resource url: 'js/ember.js', attrs: [googlecompiler: [languageIn: CompilerOptions.LanguageMode.ECMASCRIPT5]]
```
