### PR TITLE
removed runtime dependency on a specific version of resources plugin

### DIFF
--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -17,7 +17,6 @@ grails.project.dependency.resolution = {
     }
     dependencies {
         // specify dependencies here under either 'build', 'compile', 'runtime', 'test' or 'provided' scopes eg.
-        runtime "org.grails.plugins:resources:1.1.6"
         compile 'com.google.javascript:closure-compiler:r1918'
     }
 


### PR DESCRIPTION
The plugin descriptor already depends on resources.  Adding a specific section in the dependencies causes issues if you are using a different version of resource. 

Users will be presented with this message:
"You currently already have a version of the plugin installed [resources-1.2.RC2]. Do you want to update to [resources-1.1.6]? [y,n]"
or it will fail with the --non-interactive flag
